### PR TITLE
Fix crucial typo in pedestrian Social Force potential definition

### DIFF
--- a/guide/pedped_1d.ipynb
+++ b/guide/pedped_1d.ipynb
@@ -39,7 +39,7 @@
     "with its two parameters $V_0$ and $\\sigma$. Although it is a single-argument\n",
     "function, the argument $b$ is the semi-minor axis of an ellipse, a 2D object:\n",
     "\\begin{align}\n",
-    "    2b &= \\sqrt{||\\vec{r}_{\\alpha\\beta}|| + ||\\vec{r}_{\\alpha\\beta} - v_{\\beta}\\Delta t \\vec{e}_{\\beta}|| - (v_{\\beta}\\Delta t)^2}\n",
+    "    2b &= \\sqrt{(||\\vec{r}_{\\alpha\\beta}|| + ||\\vec{r}_{\\alpha\\beta} - v_{\\beta}\\Delta t \\vec{e}_{\\beta}||)^2 - (v_{\\beta}\\Delta t)^2}\n",
     "\\end{align}\n",
     "as defined in {cite}`helbing1995social` with $\\vec{r}_{\\alpha\\beta} = \\vec{r}_{\\alpha} - \\vec{r}_{\\beta}$. \n",
     "We can compare this with $2b = \\sqrt{(p + q)^2 - d^2}$ where the\n",


### PR DESCRIPTION
The formula for the ellipse's semi-minor axis was missing the square for the focal points.

Wrong (before):
![grafik](https://github.com/svenkreiss/socialforce/assets/93079021/3888d155-6a2b-4c5e-aed6-fe0a9094464e)

Correct (now):
![grafik](https://github.com/svenkreiss/socialforce/assets/93079021/b78d121e-da1a-4309-ac16-2aa9cf4552a9)
